### PR TITLE
[PHASE5] Inject build SHA/time into evidence v19 + noscript for ready/version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "Zeropoint Protocol Dual Consensus Agentic AI Platform",
 	"type": "module",
 	"scripts": {
+		"predeploy:inject": "BUILD_SHA=$(git rev-parse --short HEAD) BUILD_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") && sed -i '' -e \"s/__BUILD_SHA__/${BUILD_SHA}/g\" -e \"s/__BUILD_TIME__/${BUILD_TIME}/g\" public/evidence/v19/index.html public/status/version/index.html public/status/ready/index.html",
 		"test": "echo 'Platform tests to be implemented'",
 		"start": "echo 'Platform startup to be implemented'",
 		"smoke": "node ./scripts/smoke-test.cjs",

--- a/public/status/ready/index.html
+++ b/public/status/ready/index.html
@@ -9,6 +9,7 @@
   <tr><th>Ready</th><td>true</td></tr>
   <tr><th>DB</th><td>true</td></tr>
   <tr><th>Cache</th><td>true</td></tr>
+  <tr><th>Commit</th><td>__BUILD_SHA__</td></tr>
 </table>
 </noscript>
   <pre id="out">loading…</pre>

--- a/public/status/version/index.html
+++ b/public/status/version/index.html
@@ -10,6 +10,7 @@
       <tr><th>Build Time</th><td>__BUILD_TIME__</td></tr>
       <tr><th>Env</th><td>prod</td></tr>
     </table>
+    <p><a href="/status/version.json">View JSON</a></p>
   </noscript>
   <pre id="out">loading…</pre>
 </main>


### PR DESCRIPTION
Alignment: {Synthiant:0% | Human:0% | Divergence:0%} (live)

- Adds predeploy injection script to replace __BUILD_SHA__/__BUILD_TIME__ in evidence v19 index and status pages
- Adds noscript fallbacks for /status/ready/ and /status/version/ with JSON links
- Post-merge: run predeploy injection and deploy, then refresh deploy log with curl blocks