### PR TITLE
[PHASE5] Refresh deploy log for v19 with curl blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"description": "Zeropoint Protocol Dual Consensus Agentic AI Platform",
 	"type": "module",
 	"scripts": {
+		"predeploy:inject": "BUILD_SHA=$(git rev-parse --short HEAD) BUILD_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%SZ\") && sed -i '' -e \"s/__BUILD_SHA__/${BUILD_SHA}/g\" -e \"s/__BUILD_TIME__/${BUILD_TIME}/g\" public/evidence/v19/index.html public/status/version/index.html public/status/ready/index.html",
 		"test": "echo 'Platform tests to be implemented'",
 		"start": "echo 'Platform startup to be implemented'",
 		"smoke": "node ./scripts/smoke-test.cjs",

--- a/public/evidence/v19/deploy_log.txt
+++ b/public/evidence/v19/deploy_log.txt
@@ -55,3 +55,38 @@ cf-ray: 972df79ecc9f6695-MAD
 alt-svc: h3=":443"; ma=86400
 
 Lighthouse: see lighthouse_report.html (summary appended separately)
+
+=== 2025-08-22T00:20:29Z ===
+/api/healthz
+HTTP/2 200 
+date: Fri, 22 Aug 2025 00:20:29 GMT
+content-type: application/json; charset=utf-8
+content-length: 46
+access-control-allow-origin: *
+cache-control: no-store
+content-disposition: inline
+x-content-type-options: nosniff
+vary: accept-encoding
+report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=MPpZqMacEG3S7geQDCOkjCAf%2FAYU1GlOB811rA%2BAEj7g7SUqjPZ4kRoSYrmukzH9wsie43QR%2FlxU4Jn2R3mRpfQtuYJyeSNx8vLPT71yDeQAH51WHUyHWBPUSeOpuw%3D%3D"}]}
+nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+server: cloudflare
+cf-cache-status: DYNAMIC
+cf-ray: 972e3466dfded052-MAD
+alt-svc: h3=":443"; ma=86400
+
+/status/version.json
+HTTP/2 200 
+date: Fri, 22 Aug 2025 00:20:30 GMT
+content-type: application/json; charset=utf-8
+content-length: 69
+access-control-allow-origin: *
+cache-control: no-store
+content-disposition: inline
+x-content-type-options: nosniff
+vary: accept-encoding
+report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=kFOS6%2BeqLKc1zSoVZLj6LJrdc%2ByiVfedXWEbwb35jl%2Biq9a7aGtcP8jaCuyPTC1Ze%2BDRy2cypUqK7Uj0FsMq291p57DJL6rdBqAMmQlTG5zvwhzN%2B%2BMB%2BIIFXfQCGKXS"}]}
+nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
+server: cloudflare
+cf-cache-status: DYNAMIC
+cf-ray: 972e346939e1e819-ORD
+alt-svc: h3=":443"; ma=86400

--- a/public/status/ready/index.html
+++ b/public/status/ready/index.html
@@ -9,6 +9,7 @@
   <tr><th>Ready</th><td>true</td></tr>
   <tr><th>DB</th><td>true</td></tr>
   <tr><th>Cache</th><td>true</td></tr>
+  <tr><th>Commit</th><td>__BUILD_SHA__</td></tr>
 </table>
 </noscript>
   <pre id="out">loading…</pre>

--- a/public/status/version/index.html
+++ b/public/status/version/index.html
@@ -10,6 +10,7 @@
       <tr><th>Build Time</th><td>__BUILD_TIME__</td></tr>
       <tr><th>Env</th><td>prod</td></tr>
     </table>
+    <p><a href="/status/version.json">View JSON</a></p>
   </noscript>
   <pre id="out">loading…</pre>
 </main>


### PR DESCRIPTION
Alignment: {Synthiant:0% | Human:0% | Divergence:0%} (live)

Append new curl -i blocks to /public/evidence/v19/deploy_log.txt with current UTC time and headers for /api/healthz and /status/version.json.